### PR TITLE
Make the buildsystem more consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-*
-!*.*
-!*/
-
+*.mod
 *.iso
 *.o
 *.pyc
@@ -13,6 +10,7 @@
 *.map
 *.img
 misc/grub.cfg
+misc/root
 isodir
 sysroot
 toolchain/build

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -5,34 +5,36 @@ LIBS=-lk
 OBJS:=$(patsubst %.c,%.o,$(shell find src -name '*.c'))
 OBJS+=$(patsubst %.S,%.o,$(shell find src -name '*.S'))
 
+LIBK_DEP=$(LIBDIR)/libk.a
+
+KERNEL=$(ISO)/$(BOOTDIR)/SnowflakeOS.kernel
+SYMBOLS=$(ISO)/modules/symbols.map
+
 .PHONY: all clean build install-headers install-kernel
 
-SnowflakeOS.kernel symbols.map: $(OBJS) linker.ld
-	$(info [kernel] linking kernel)
-	@$(LD) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+$(KERNEL) $(SYMBOLS): $(OBJS) $(LIBK_DEP) linker.ld
+	$(info [kernel] linking)
+	@mkdir -p $(ISO)/$(BOOTDIR)
+	@$(LD) $(LDFLAGS) -o $(KERNEL) $(OBJS) $(LIBS)
 	$(info [kernel] generating symbol table)
-	@awk '$$1 ~ /0x[0-9a-f]{16}/ {print substr($$1, 3), $$2}' linker.map > symbols.map
 	@mkdir -p $(ISO)/modules
-	@cp symbols.map $(ISO)/modules/
+	@awk '$$1 ~ /0x[0-9a-f]{16}/ {print substr($$1, 3), $$2}' linker.map > $(SYMBOLS)
 	@rm linker.map
 
 %.o: %.c
-	$(info [kernel] building $@)
+	$(info [kernel] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 %.o: %.S
-	$(info [kernel] building $@)
+	$(info [kernel] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
-build: SnowflakeOS.kernel
-	$(info [kernel] installing)
-	@mkdir -p $(ISO)/$(BOOTDIR)
-	@cp SnowflakeOS.kernel $(ISO)/$(BOOTDIR)
+build: $(KERNEL)
 
 install-headers:
 	$(info [kernel] installing headers)
-	@mkdir -p $(SYSROOT)/$(INCLUDEDIR)
-	@cp -rT include $(SYSROOT)/$(INCLUDEDIR)
+	@mkdir -p $(INCLUDEDIR)
+	@cp -rT include $(INCLUDEDIR)
 
 clean:
 	$(info [kernel] cleaning)

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,58 +1,50 @@
 LIBK_CFLAGS:=$(CFLAGS) -D_KERNEL_
 CFLAGS+=-Wno-format
 
-OBJS:=$(patsubst %.c,%.o,$(wildcard src/*/*.c))
-OBJS+=$(patsubst %.c,%.o,$(wildcard src/*.c))
-
-
-OBJS+=$(patsubst %.S,%.o,$(wildcard src/*/*.S))
-OBJS+=$(patsubst %.S,%.o,$(wildcard src/*.S))
+OBJS+=$(patsubst %.c,%.o,$(shell find src/ -name '*.c'))
+OBJS+=$(patsubst %.S,%.o,$(shell find src/ -name '*.S'))
 
 LIBK_OBJS:=$(OBJS:.o=.libk.o)
 
 # libk is libc but compiled with _KERNEL_ defined
-BINARIES=libc.a libk.a
+LIBC=$(LIBDIR)/libc.a
+LIBK=$(LIBDIR)/libk.a
 
-all: $(BINARIES)
+.PHONY: all clean build install-headers
 
-.PHONY: all clean build install-headers install-libs
-
-libc.a: $(OBJS)
-	$(info [libc] linking $@)
+$(LIBC): $(OBJS)
+	$(info [libc] linking $(notdir $@))
+	@mkdir -p $(LIBDIR)
 	@$(AR) rcs $@ $(OBJS)
 
-libk.a: $(LIBK_OBJS)
-	$(info [libc] linking $@)
+$(LIBK): $(LIBK_OBJS)
+	$(info [libc] linking $(notdir $@))
+	@mkdir -p $(LIBDIR)
 	@$(AR) rcs $@ $(LIBK_OBJS)
 
 %.o: %.c
-	$(info [libc] building $@)
+	$(info [libc] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 %.o: %.S
-	$(info [libc] building $@)
+	$(info [libc] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 %.libk.o: %.c
-	$(info [libc] building $@)
+	$(info [libc] $@)
 	@$(CC) -c $< -o $@ $(LIBK_CFLAGS)
 
 %.libk.o: %.S
-	$(info [libc] building $@)
+	$(info [libc] $@)
 	@$(CC) -c $< -o $@ $(LIBK_CFLAGS)
 
 clean:
 	$(info [libc] cleaning up)
-	@rm -f $(BINARIES) $(OBJS) $(LIBK_OBJS) *.o */*.o */*/*.o
+	@rm -f $(OBJS) $(LIBK_OBJS) *.o */*.o */*/*.o
 
-build: install-libs
+build: $(LIBC) $(LIBK)
 
 install-headers:
 	$(info [libc] installing headers)
-	@mkdir -p $(SYSROOT)/$(INCLUDEDIR)
-	@cp -rT include $(SYSROOT)/$(INCLUDEDIR)
-
-install-libs: $(BINARIES)
-	$(info [libc] installing shared libraries)
-	@mkdir -p $(SYSROOT)/$(LIBDIR)
-	@cp $(BINARIES) $(SYSROOT)/$(LIBDIR)
+	@mkdir -p $(INCLUDEDIR)
+	@cp -rT include $(INCLUDEDIR)

--- a/libc/src/dirent.c
+++ b/libc/src/dirent.c
@@ -1,13 +1,15 @@
 #ifndef _KERNEL_
 
 #include <kernel/uapi/uapi_fs.h>
+#include <kernel/uapi/uapi_syscall.h>
 
 #include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 
-#include <snow.h>
+extern int32_t syscall1(uint32_t eax, uint32_t ebx);
+extern int32_t syscall2(uint32_t eax, uint32_t ebx, uint32_t ecx);
 
 /* Opens the directory pointed to by `path` and returns a directory handle.
  * This handle can later be freed by calling `closedir`.

--- a/libc/src/stdlib/malloc.c
+++ b/libc/src/stdlib/malloc.c
@@ -9,10 +9,6 @@
 #include <kernel/sys.h>
 #endif
 
-#ifndef _KERNEL_
-#include <snow.h>
-#endif
-
 #define MIN_ALIGN 4
 
 typedef struct _mem_block_t {

--- a/libc/src/string/memset.c
+++ b/libc/src/string/memset.c
@@ -3,8 +3,9 @@
 void* memset(void* bufptr, int value, size_t size) {
     unsigned char* buf = (unsigned char*) bufptr;
 
-    for (size_t i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++) {
         buf[i] = (unsigned char) value;
+    }
 
     return bufptr;
 }

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -2,15 +2,17 @@ CFLAGS:=$(CFLAGS)
 LDFLAGS:=$(LDFLAGS) -Tmod.ld
 LIBS=-lui -lsnow -lc
 
+LIB_DEPS=$(LIBDIR)/libc.a $(LIBDIR)/libui.a $(LIBDIR)/libsnow.a
+
 MODS=$(patsubst %.c,%,$(wildcard src/*.c))
-MODS_BUILD=$(patsubst %.c,%.mod,$(wildcard src/*.c))
+MODS:=$(notdir $(MODS))
+MODS:=$(MODS:%=$(TARGETROOT)/%)
+EXECUTABLES=$(notdir $(MODS))
+OBJS=$(EXECUTABLES:%=src/%.o)
 
 .PHONY: build install-headers clean
 
 build: $(MODS)
-	$(info [modules] copying modules)
-	@mkdir -p $(TARGETROOT)
-	@cp $(MODS) $(TARGETROOT)
 
 install-headers:
 
@@ -19,16 +21,15 @@ clean:
 	@rm -f */*.o
 	@find . -executable -type f -delete
 
-$(MODS): % : %.mod
-	$(info [modules] building $@)
-	@mv $^ $@
+# TODO: every module depends on every other, a change in one rebuilds all of them
+$(MODS): $(OBJS) $(LIB_DEPS) src/start.o
+	$(info [modules] $(notdir $@))
+	@mkdir -p $(TARGETROOT)
+	@$(LD) src/start.o src/$(@F).o -o $@ $(LDFLAGS) $(LIBS)
 
-%.mod: %.c mod.ld src/start.o FORCE
-	@$(CC) -c $< -o $*.o $(CFLAGS)
-	@$(LD) src/start.o $*.o -o $@ $(LDFLAGS) $(LIBS)
+%.o: %.c
+	@$(CC) -c $< -o $@ $(CFLAGS)
 
 %.o: %.S
-	$(info [modules] building $@)
+	$(info [modules] $@)
 	@$(AS) $(ASFLAGS) $< -o $@
-
-FORCE:

--- a/modules/src/terminal.c
+++ b/modules/src/terminal.c
@@ -114,7 +114,7 @@ int main() {
     str_free(text_buf);
     str_free(input_buf);
 
-    // snow_close_window(win);
+    snow_close_window(win);
 
     return 0;
 }

--- a/snow/Makefile
+++ b/snow/Makefile
@@ -1,34 +1,30 @@
 OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c))
 OBJS+=$(patsubst %.S,%.o,$(wildcard src/*.S))
 
-all: libsnow.a
+LIBSNOW=$(LIBDIR)/libsnow.a
 
-.PHONY: all clean build install-headers install-libs
+.PHONY: all clean build install-headers
 
-libsnow.a: $(OBJS)
-	$(info [snow] linking $@)
+$(LIBSNOW): $(OBJS)
+	$(info [snow] linking $(notdir $@))
+	mkdir -p $(LIBDIR)
 	@$(AR) rcs $@ $(OBJS)
 
 %.o: %.c
-	$(info [snow] building $@)
+	$(info [snow] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 %.o: %.S
-	$(info [snow] building $@)
+	$(info [snow] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 clean:
 	$(info [snow] cleaning up)
 	@rm -f *.a $(OBJS)
 
-build: install-libs
+build: $(LIBSNOW)
 
 install-headers:
 	$(info [snow] installing headers)
-	@mkdir -p $(SYSROOT)/$(INCLUDEDIR)
-	@cp -rT include $(SYSROOT)/$(INCLUDEDIR)
-
-install-libs: libsnow.a
-	$(info [snow] installing shared libraries)
-	@mkdir -p $(SYSROOT)/$(LIBDIR)
-	@cp libsnow.a $(SYSROOT)/$(LIBDIR)
+	@mkdir -p $(INCLUDEDIR)
+	@cp -rT include $(INCLUDEDIR)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,30 +1,26 @@
 OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c))
 OBJS+=$(patsubst %.S,%.o,$(wildcard src/*.S))
 
-all: libui.a
+LIBUI=$(LIBDIR)/libui.a
 
-.PHONY: all clean build install-headers install-libs
+.PHONY: all clean build install-headers
 
-libui.a: $(OBJS)
-	$(info [ui] linking $@)
+$(LIBUI): $(OBJS)
+	$(info [ui] linking $(notdir $@))
+	@mkdir -p $(LIBDIR)
 	@$(AR) rcs $@ $(OBJS)
 
 %.o: %.c
-	$(info [ui] building $@)
+	$(info [ui] $@)
 	@$(CC) -c $< -o $@ $(CFLAGS)
 
 clean:
-	$(info [ui] building $@)
+	$(info [ui] $@)
 	@rm -f *.a $(OBJS)
 
-build: install-libs
+build: $(LIBUI)
 
 install-headers:
 	$(info [ui] installing headers)
-	@mkdir -p $(SYSROOT)/$(INCLUDEDIR)
-	@cp -rT include $(SYSROOT)/$(INCLUDEDIR)
-
-install-libs: libui.a
-	$(info [ui] installing shared libraries)
-	@mkdir -p $(SYSROOT)/$(LIBDIR)
-	@cp libui.a $(SYSROOT)/$(LIBDIR)
+	@mkdir -p $(INCLUDEDIR)
+	@cp -rT include $(INCLUDEDIR)


### PR DESCRIPTION
Used to be, when you made a change in the libc, the kernel didn't get
rebuilt by a call to `make`. Now it does! I _will_ get the hang of
Makefile good practices.
Still an inconvenience in the way modules (aka apps) are built: they
each have all of the other as dependencies, so a change in one triggers
a rebuild of all of them.